### PR TITLE
Last_edited added to Location. Location/Splash pages display last_edited date if it is different from the posted date

### DIFF
--- a/client/src/containers/AddReview/AddReview.js
+++ b/client/src/containers/AddReview/AddReview.js
@@ -60,7 +60,7 @@ class AddReview extends React.Component {
 
   render() {
     const { text, stars, review_id } = this.state;
-    const { addReview } = this.props;
+    const { addReview, existingReview } = this.props;
 
     return (
       <ReviewForm onSubmit={() => addReview(text, stars, review_id)}>
@@ -83,7 +83,11 @@ class AddReview extends React.Component {
           onChange={this.handleChange}
         />
 
-        <Button type="submit">Submit Review</Button>
+        { existingReview ? (
+          <Button type="submit">Edit Review</Button>
+        ) : (
+          <Button type="submit">Submit Review</Button>
+        )}
       </ReviewForm>
     );
   }

--- a/client/src/containers/Location/Location.js
+++ b/client/src/containers/Location/Location.js
@@ -85,6 +85,7 @@ class Location extends React.Component {
           text
           stars
           posted
+          last_edited
         }
       }
     }

--- a/client/src/containers/Recents.js
+++ b/client/src/containers/Recents.js
@@ -71,7 +71,7 @@ class Recents extends React.Component {
         getRecents(num: ${num}) {
           text
           stars
-          posted
+          last_edited
           user {
             _id
             username
@@ -97,7 +97,7 @@ class Recents extends React.Component {
             {
               text: 'Something went wrong',
               stars: 0,
-              posted: 1,
+              last_edited: 1,
               user: {
                 username: 'The App',
                 _id: 0,
@@ -116,7 +116,7 @@ class Recents extends React.Component {
       if (a === null) return null;
       const shortened = a.text.length > 80 ? `${a.text.substring(0, 80)}...` : a.text;
       return (
-        <Item key={a.posted}>
+        <Item key={a.last_edited}>
           <p>
             <Link to={`/location/${a.location._id}`}>{a.location.placename}</Link>
           </p>
@@ -124,7 +124,7 @@ class Recents extends React.Component {
           <p>{shortened}</p>
           <p style={{ justifySelf: 'flex-end' }}>
             ~ <Link to={`/user/${a.user._id}`}>{a.user.username}</Link>,{' '}
-            {new Date(a.posted).toDateString()}
+            {new Date(a.last_edited).toDateString()}
           </p>
         </Item>
       );

--- a/client/src/containers/Review/Review.js
+++ b/client/src/containers/Review/Review.js
@@ -56,7 +56,7 @@ class Review extends React.Component {
   render() {
     const { rev, the_reviewers_id, handleDelete } = this.props;
     const { user_id } = this.state;
-    const edited = (rev.posted !== rev.last_edited) ? true : false;
+    const wasEdited = (rev.posted !== rev.last_edited) ? true : false;
     let topLine;
     let linkTo;
     if (rev.location) {
@@ -80,13 +80,11 @@ class Review extends React.Component {
         </TopLine>
         <Stars stars={rev.stars} outOf={5} full="#134999" empty="#fff" stroke="#000" />
         <RevText>{rev.text}</RevText>
-        <PostedText>
-          { edited ? (
-            review edited {new Date(rev.last_edited).toDateString()}
-          ) : (
-            review posted {new Date(rev.posted).toDateString()}
-          )}
-        </PostedText>
+        { wasEdited ? (
+          <PostedText> review edited {new Date(rev.last_edited).toDateString()} </PostedText>
+        ) : (
+          <PostedText> review posted {new Date(rev.posted).toDateString()} </PostedText>
+        )}
       </RevWrap>
     );
   }

--- a/client/src/containers/Review/Review.js
+++ b/client/src/containers/Review/Review.js
@@ -56,6 +56,7 @@ class Review extends React.Component {
   render() {
     const { rev, the_reviewers_id, handleDelete } = this.props;
     const { user_id } = this.state;
+    const edited = (rev.posted !== rev.last_edited) ? true : false;
     let topLine;
     let linkTo;
     if (rev.location) {
@@ -79,7 +80,13 @@ class Review extends React.Component {
         </TopLine>
         <Stars stars={rev.stars} outOf={5} full="#134999" empty="#fff" stroke="#000" />
         <RevText>{rev.text}</RevText>
-        <PostedText>review posted {new Date(rev.posted).toDateString()}</PostedText>
+        <PostedText>
+          { edited ? (
+            review edited {new Date(rev.last_edited).toDateString()}
+          ) : (
+            review posted {new Date(rev.posted).toDateString()}
+          )}
+        </PostedText>
       </RevWrap>
     );
   }


### PR DESCRIPTION
The location page also queries for the last_edited property. If last_edited != posted, the review shows 'review edited on...' rather than 'rather posted on...'.
For the splash page, I just had them retrieve their last_edited property instead of posted, because they were being sorted by last_edited anyways.
It all works because when a new Review is created, both its posted and last_edited are set to the same value.